### PR TITLE
Update to fastify4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [4.0.0](https://github.com/smartiniOnGitHub/fastify-healthcheck/releases/tag/4.0.0) (unreleased)
+[Full Changelog](https://github.com/smartiniOnGitHub/fastify-healthcheck/compare/3.2.0...4.0.0)
+Summary Changelog:
+- Updated requirements to Fastify '^4.0.0'; update code with related changes
+- Updated all dependencies to latest (for Node.js 14 LTS)
+- Update dependencies from 'under-pressure' to the new (scoped) 
+  package '@fastify/under-pressure'
+- Update and simplified example and test code
+- Update documentation from sources with JSDoc
+
 ## [3.2.0](https://github.com/smartiniOnGitHub/fastify-healthcheck/releases/tag/3.2.0) (2022-06-13)
 [Full Changelog](https://github.com/smartiniOnGitHub/fastify-healthcheck/compare/3.1.0...3.2.0)
 Summary Changelog:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ will be used, but if needed can be specified:
 - `exposeUptime`, to return even Node.js process uptime (by default disabled)
 
 Under the hood, the healthcheck status is determined by the 
-[under-pressure](https://www.npmjs.com/package/under-pressure) plugin, 
+[@fastify/under-pressure](https://www.npmjs.com/package/@fastify/under-pressure) plugin, 
 used here as a dependency; so it's possible to specify all its
 configuration options here.
 
@@ -47,7 +47,7 @@ fastify.register(require('fastify-healthcheck'))
 // fastify.register(require('fastify-healthcheck'), { healthcheckUrl: '/custom-health', healthcheckUrlAlwaysFail: true })
 //
 
-fastify.listen(3000)
+fastify.listen({ port: 3000, host: 'localhost' })
 
 // To test, for example (in another terminal session) do:
 // `npm start`, or
@@ -85,8 +85,8 @@ like in the following sequence:
 
 ## Requirements
 
-Fastify ^3.11.0 , Node.js 10 LTS (10.13.0) or later.
-Note that plugin releases 2.x are for Fastify 2.x, 3.x are for Fastify 3.x, etc.
+Fastify ^4.0.0 , Node.js 14 LTS (14.15.0) or later.
+Note that plugin releases 3.x are for Fastify 3.x, 4.x are for Fastify 4.x, etc.
 
 
 ## Sources

--- a/example/example-under-pressure-fail.js
+++ b/example/example-under-pressure-fail.js
@@ -39,7 +39,7 @@ fastify.get('/', function (req, reply) {
   reply.type('text/html; charset=utf-8').send(stream)
 })
 
-fastify.listen(3000, '0.0.0.0', (err, address) => {
+fastify.listen({ port: 3000, host: '0.0.0.0' }, (err, address) => {
   if (err) throw err
   console.log(`Server listening on ${address}`)
 })

--- a/example/example.js
+++ b/example/example.js
@@ -36,7 +36,7 @@ fastify.get('/', function (req, reply) {
   reply.type('text/html; charset=utf-8').send(stream)
 })
 
-fastify.listen(3000, '0.0.0.0', (err, address) => {
+fastify.listen({ port: 3000, host: '0.0.0.0' }, (err, address) => {
   if (err) throw err
   console.log(`Server listening on ${address}`)
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-healthcheck",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Fastify Plugin to serve responses for health checks",
   "main": "src/plugin",
   "types": "types/index.d.ts",
@@ -36,17 +36,17 @@
     "test": "npm run lint:standard && npm run lint:typescript && npm run test:types && npm run test:unit"
   },
   "dependencies": {
-    "under-pressure": "^5.8.1"
+    "@fastify/under-pressure": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.42",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
-    "fastify": "^3.11.0",
+    "fastify": "^4.0.0",
     "jsdoc": "^3.6.10",
     "simple-get": "^4.0.1",
-    "standard": "^16.0.3",
-    "tap": "^15.2.3",
+    "standard": "^17.0.0",
+    "tap": "^16.2.0",
     "tsd": "^0.21.0",
     "typescript": "^4.7.3"
   },
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {},
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=14.15.0"
   },
   "homepage": "https://github.com/smartiniOnGitHub/fastify-healthcheck#readme",
   "repository": {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,7 +39,7 @@ function fastifyHealthcheck (fastify, options, next) {
   // note that it will trigger automatic failure responses
   // in all routes defined here when current values are higher
   // that threshold values set
-  fastify.register(require('under-pressure'), underPressureOptions)
+  fastify.register(require('@fastify/under-pressure'), underPressureOptions)
 
   let healthcheckHandler = normalHandler
   if (exposeUptime === true) {

--- a/test/healthcheck.test.js
+++ b/test/healthcheck.test.js
@@ -37,7 +37,7 @@ function block (msec) {
 test('healthcheck with all defaults: does not return an error, but a good response (200) and some content', (t) => {
   // t.plan(5)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin) // configure this plugin with its default options
 
   fastify.listen({ port: 0 }, (err, address) => {
@@ -59,9 +59,8 @@ test('healthcheck with all defaults: does not return an error, but a good respon
 })
 
 test('healthcheck on a custom route: does not return an error, but a good response (200) and some content', (t) => {
-  // t.plan(11)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     healthcheckUrl: '/custom-health'
   }) // configure this plugin with some custom options
@@ -98,9 +97,8 @@ test('healthcheck on a custom route: does not return an error, but a good respon
 })
 
 test('healthcheck on a disabled route (default or custom): return a not found error (404) and some content', (t) => {
-  // t.plan(13)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     healthcheckUrl: '/custom-health',
     healthcheckUrlDisable: true
@@ -140,9 +138,8 @@ test('healthcheck on a disabled route (default or custom): return a not found er
 })
 
 test('healthcheck with always failure flag: always return an error, (500) and some content', (t) => {
-  // t.plan(5)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     // 'healthcheckUrl': '/custom-health',
     healthcheckUrlAlwaysFail: true
@@ -166,9 +163,8 @@ test('healthcheck with always failure flag: always return an error, (500) and so
 })
 
 test('healthcheck with healthcheck option enabled to return even process uptime: ensure a good response (200) will be returned', (t) => {
-  // t.plan(7)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     exposeUptime: true
   }) // configure this plugin with some custom options
@@ -195,9 +191,8 @@ test('healthcheck with healthcheck option enabled to return even process uptime:
 })
 
 test('healthcheck with all healthcheck specific options undefined: does not return an error, but a good response (200) and under-pressure defaults', (t) => {
-  // t.plan(8)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     healthcheckUrl: undefined,
     healthcheckUrlDisable: undefined,
@@ -229,9 +224,8 @@ test('healthcheck with all healthcheck specific options undefined: does not retu
 })
 
 test('healthcheck with only some under-pressure options defined: does not return an error, but a good response (200) and some content', (t) => {
-  // t.plan(6)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     underPressureOptions: {
       // exposeStatusRoute: true, // no effect here
@@ -263,9 +257,8 @@ test('healthcheck with only some under-pressure options defined: does not return
 })
 
 test('healthcheck with only some under-pressure options defined to always fail: return an error (503) and some content', (t) => {
-  // t.plan(8)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     underPressureOptions: {
       // exposeStatusRoute: true, // no effect here
@@ -308,9 +301,8 @@ test('healthcheck with only some under-pressure options defined to always fail: 
 })
 
 test('healthcheck with some under-pressure options defined for a custom response on healthcheck: does not return an error, but a good response (200) and some content', (t) => {
-  // t.plan(13)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(healthcheckPlugin, {
     underPressureOptions: {
       // set a custom healthcheck route, for example async

--- a/test/healthcheck.test.js
+++ b/test/healthcheck.test.js
@@ -40,7 +40,7 @@ test('healthcheck with all defaults: does not return an error, but a good respon
   t.teardown(fastify.close.bind(fastify))
   fastify.register(healthcheckPlugin) // configure this plugin with its default options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     process.nextTick(() => sleep(500)) // not really needed, but could be useful to have
@@ -66,7 +66,7 @@ test('healthcheck on a custom route: does not return an error, but a good respon
     healthcheckUrl: '/custom-health'
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     sget({
@@ -106,7 +106,7 @@ test('healthcheck on a disabled route (default or custom): return a not found er
     healthcheckUrlDisable: true
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     sget({
@@ -148,7 +148,7 @@ test('healthcheck with always failure flag: always return an error, (500) and so
     healthcheckUrlAlwaysFail: true
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     sget({
@@ -173,7 +173,7 @@ test('healthcheck with healthcheck option enabled to return even process uptime:
     exposeUptime: true
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     process.nextTick(() => sleep(500))
@@ -206,7 +206,7 @@ test('healthcheck with all healthcheck specific options undefined: does not retu
     underPressureOptions: { } // no under-pressure specific options set here
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     process.nextTick(() => sleep(500))
@@ -243,7 +243,7 @@ test('healthcheck with only some under-pressure options defined: does not return
     } // set some under-pressure specific options set here
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
     t.ok(!fastify.memoryUsage) // ensure is not exposed
 
@@ -277,7 +277,7 @@ test('healthcheck with only some under-pressure options defined to always fail: 
     } // set some under-pressure specific options set here
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
     t.ok(!fastify.memoryUsage) // ensure is not exposed
 
@@ -332,7 +332,7 @@ test('healthcheck with some under-pressure options defined for a custom response
     } // set some under-pressure specific options set here
   }) // configure this plugin with some custom options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     // test usual plugin healthcheck route

--- a/test/underpressure.test.js
+++ b/test/underpressure.test.js
@@ -38,7 +38,7 @@ test('Should return 503 on maxHeapUsedBytes', t => {
   // t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(underPressure, {
     maxHeapUsedBytes: 1
   })

--- a/test/underpressure.test.js
+++ b/test/underpressure.test.js
@@ -32,7 +32,7 @@ function block (msec) {
 }
 
 // test the following features even directly with original under-pressure plugin
-const underPressure = require('under-pressure')
+const underPressure = require('@fastify/under-pressure')
 
 test('Should return 503 on maxHeapUsedBytes', t => {
   // t.plan(5)
@@ -47,7 +47,7 @@ test('Should return 503 on maxHeapUsedBytes', t => {
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     process.nextTick(() => block(monitorEventLoopDelay ? 1500 : 500))

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import underPressure from 'under-pressure'
+import underPressure from '@fastify/under-pressure'
 import { FastifyPluginCallback } from 'fastify'
 
 export interface FastifyHealthcheckOptions {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,7 +12,7 @@ const options: FastifyHealthcheckOptions = {
 }
 app.register(healthcheckPlugin, options)
 
-app.listen(3000, (err, address) => {
+app.listen({ port: 3000 }, (err, address) => {
   if (err) throw err
   console.log(`Server listening on '${address}' ...`)
 })


### PR DESCRIPTION
Update to Fastify 4.x (and so Node.js 14 LTS) and the new version of the (scoped) package '@fastify/under-pressure'.
