### PR TITLE
Update to the next version of under-pressure / fix TS 4.8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,19 +37,18 @@
     "test": "npm run lint:standard && npm run lint:typescript && npm run test:types && npm run test:unit"
   },
   "dependencies": {
-    "@fastify/under-pressure": "^7.0.0"
+    "@fastify/under-pressure": "^8.1.0"
   },
   "devDependencies": {
-    "@types/node": "^18.0.6",
-    "@typescript-eslint/eslint-plugin": "^5.30.7",
-    "@typescript-eslint/parser": "^5.30.7",
-    "fastify": "^4.0.1",
-    "jsdoc": "^3.6.10",
+    "@types/node": "^18.7.14",
+    "@typescript-eslint/eslint-plugin": "^5.36.1",
+    "@typescript-eslint/parser": "^5.36.1",
+    "fastify": "^4.5.3",
+    "jsdoc": "^3.6.11",
     "simple-get": "^4.0.1",
     "standard": "^17.0.0",
     "tap": "^16.3.0",
-    "tsd": "^0.22.0",
-    "typescript": "^4.7.4"
+    "tsd": "^0.23.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
This change makes the plugin compatible with TypeScript 4.8

See https://github.com/fastify/under-pressure/releases/tag/v8.0.0 -> from my understanding the breaking change here is switch from fastify-plugin 3 to fastify-plugin 4, which is no longer compatible with fastify 3. 

Not sure if healthcheck was still supporting fastify 3, if yes, this is a semver major change.
