### PR TITLE
Adds schema options for health endpoint

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -48,44 +48,7 @@ function fastifyHealthcheck (fastify, options, done) {
     healthcheckUrlAlwaysFail = false,
     exposeUptime = false,
     underPressureOptions = { },
-    schemaOptions = {
-      operationId: "getHealth",
-      description: "Serve responses for health checks",
-      response: {
-        500: {
-          content: {
-            "application/json": {
-              schema: {
-                statusCode: {
-                  type: 'number'
-                },
-                status: {
-                  type: 'string'
-                }
-              },
-            },
-          },
-        },
-        200: {
-          content: {
-            "application/json": {
-              schema: {
-                statusCode: {
-                  type: 'number'
-                },
-                status: {
-                  type: 'string'
-                },
-                uptime: {
-                  type: 'number',
-                  optional: true
-                }
-              }
-            },
-          },
-        },
-      },
-    },
+    schemaOptions
   } = options
 
   ensureIsString(healthcheckUrl, 'healthcheckUrl')
@@ -93,7 +56,9 @@ function fastifyHealthcheck (fastify, options, done) {
   ensureIsBoolean(healthcheckUrlAlwaysFail, 'healthcheckUrlAlwaysFail')
   ensureIsBoolean(exposeUptime, 'exposeUptime')
   ensureIsObject(underPressureOptions, 'underPressureOptions')
-  ensureIsObject(schemaOptions, 'schemaOptions')
+  if (schemaOptions) {
+    ensureIsObject(schemaOptions, 'schemaOptions')
+  }
 
   // execute plugin code
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,6 +35,7 @@ const payloadKO = { statusCode: 500, status: 'ko' }
  *     <li>healthcheckUrlAlwaysFail (boolean, default false) flag to always return failure from health check route (mainly for testing purposes),</li>
  *     <li>exposeUptime (boolean, default false) flag to show even process uptime in health check results,</li>
  *     <li>underPressureOptions (object, default empty) for options to send directly to under-pressure,</li>
+ *     <li>schemaOptions (object, default empty) for options to use for route schema,</li>
  * </ul>
  * @param {!function} done callback, to call as last step
  *
@@ -46,7 +47,45 @@ function fastifyHealthcheck (fastify, options, done) {
     healthcheckUrlDisable = false,
     healthcheckUrlAlwaysFail = false,
     exposeUptime = false,
-    underPressureOptions = { }
+    underPressureOptions = { },
+    schemaOptions = {
+      operationId: "getHealth",
+      description: "Serve responses for health checks",
+      response: {
+        500: {
+          content: {
+            "application/json": {
+              schema: {
+                statusCode: {
+                  type: 'number'
+                },
+                status: {
+                  type: 'string'
+                }
+              },
+            },
+          },
+        },
+        200: {
+          content: {
+            "application/json": {
+              schema: {
+                statusCode: {
+                  type: 'number'
+                },
+                status: {
+                  type: 'string'
+                },
+                uptime: {
+                  type: 'number',
+                  optional: true
+                }
+              }
+            },
+          },
+        },
+      },
+    },
   } = options
 
   ensureIsString(healthcheckUrl, 'healthcheckUrl')
@@ -54,6 +93,7 @@ function fastifyHealthcheck (fastify, options, done) {
   ensureIsBoolean(healthcheckUrlAlwaysFail, 'healthcheckUrlAlwaysFail')
   ensureIsBoolean(exposeUptime, 'exposeUptime')
   ensureIsObject(underPressureOptions, 'underPressureOptions')
+  ensureIsObject(schemaOptions, 'schemaOptions')
 
   // execute plugin code
 
@@ -75,7 +115,8 @@ function fastifyHealthcheck (fastify, options, done) {
     fastify.route({
       method: 'GET',
       url: healthcheckUrl,
-      handler: healthcheckHandler
+      handler: healthcheckHandler,
+      schema: schemaOptions
     })
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,11 @@ declare namespace fastifyHealthcheck {
      * Override options for under-pressure (default: {}).
      */
     underPressureOptions?: UnderPressureOptions
+
+    /**
+     * Fastify schema for the healthcheck route (default: undefined).
+     */
+    schemaOptions?: unknown
   }
 
   export const fastifyHealthcheck: FastifyHealthcheckPlugin

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -27,35 +27,19 @@ expectAssignable<FastifyHealthcheckOptions>({
     operationId: 'getHealth',
     description: 'Serve responses for health checks',
     response: {
-      500: {
-        content: {
-          'application/json': {
-            schema: {
-              statusCode: {
-                type: 'number'
-              },
-              status: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      },
-      200: {
-        content: {
-          'application/json': {
-            schema: {
-              statusCode: {
-                type: 'number'
-              },
-              status: {
-                type: 'string'
-              },
-              uptime: {
-                type: 'number',
-                optional: true
-              }
-            }
+      default: {
+        description: 'Default Response',
+        type: 'object',
+        properties: {
+          statusCode: {
+            type: 'number'
+          },
+          status: {
+            type: 'string'
+          },
+          uptime: {
+            type: 'number',
+            optional: true
           }
         }
       }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -22,5 +22,43 @@ expectAssignable<FastifyHealthcheckOptions>({
   healthcheckUrl: '/health',
   healthcheckUrlDisable: true,
   healthcheckUrlAlwaysFail: true,
-  exposeUptime: true
+  exposeUptime: true,
+  schemaOptions: {
+    operationId: 'getHealth',
+    description: 'Serve responses for health checks',
+    response: {
+      500: {
+        content: {
+          'application/json': {
+            schema: {
+              statusCode: {
+                type: 'number'
+              },
+              status: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      },
+      200: {
+        content: {
+          'application/json': {
+            schema: {
+              statusCode: {
+                type: 'number'
+              },
+              status: {
+                type: 'string'
+              },
+              uptime: {
+                type: 'number',
+                optional: true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 })


### PR DESCRIPTION
Hello, hope you're well and that you don't mind me raising a PR into your library.

When creating routes, with Fastify, we need to extend the default schema for endpoints in order to generate swagger files which are usable by GCP's API Gateway / Envoy.  As an example, every endpoint requires an `operationId` added.

I've created this PR to optionally allow through `schema` which can be applied to the endpoint for this use case.

In its default usage the schema options are `undefined` and optional with the affect being as they are currently are.  By providing `schemaOptions` they will be provided through alongside the route definition.

Note the typing is `unknown` matching that of Fastify for input to `addRoute()`.

Happy to chat about the approach or to find alternatives.