### PR TITLE
feat: add `configOptions` to allow passing `config` to route

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,6 +36,7 @@ const payloadKO = { statusCode: 500, status: 'ko' }
  *     <li>exposeUptime (boolean, default false) flag to show even process uptime in health check results,</li>
  *     <li>underPressureOptions (object, default empty) for options to send directly to under-pressure,</li>
  *     <li>schemaOptions (object, default empty) for options to use for route schema,</li>
+ *     <li>configOptions (object, default empty) for options to use for route config,</li>
  * </ul>
  * @param {!function} done callback, to call as last step
  *
@@ -48,7 +49,8 @@ function fastifyHealthcheck (fastify, options, done) {
     healthcheckUrlAlwaysFail = false,
     exposeUptime = false,
     underPressureOptions = { },
-    schemaOptions
+    schemaOptions,
+    configOptions
   } = options
 
   ensureIsString(healthcheckUrl, 'healthcheckUrl')
@@ -58,6 +60,10 @@ function fastifyHealthcheck (fastify, options, done) {
   ensureIsObject(underPressureOptions, 'underPressureOptions')
   if (schemaOptions) {
     ensureIsObject(schemaOptions, 'schemaOptions')
+  }
+
+  if (configOptions) {
+    ensureIsObject(configOptions, 'configOptions')
   }
 
   // execute plugin code
@@ -81,7 +87,8 @@ function fastifyHealthcheck (fastify, options, done) {
       method: 'GET',
       url: healthcheckUrl,
       handler: healthcheckHandler,
-      schema: schemaOptions
+      schema: schemaOptions,
+      config: configOptions
     })
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,6 +39,11 @@ declare namespace fastifyHealthcheck {
      * Fastify schema for the healthcheck route (default: undefined).
      */
     schemaOptions?: unknown
+
+    /**
+     * Fastify route config for the healthcheck route (default: undefined). See https://fastify.dev/docs/latest/Reference/Routes/#config
+     */
+    configOptions?: unknown
   }
 
   export const fastifyHealthcheck: FastifyHealthcheckPlugin

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -44,5 +44,8 @@ expectAssignable<FastifyHealthcheckOptions>({
         }
       }
     }
+  },
+  configOptions: {
+    hello: 'world'
   }
 })


### PR DESCRIPTION
I need to add a [configuration object](https://fastify.dev/docs/latest/Reference/Routes/#config) to the `healthcheck` route.

This PR adds a new `configOptions` parameter to the plugin options object and passes it to the `config` option of the `fastify.route` definition.